### PR TITLE
ステップ12対応、登録不許可時にバリデーションメッセージを表示（バリデーション自体は以前より追加済み

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -44,7 +44,7 @@ class TasksController < ApplicationController
       if @task.save
         format.html{redirect_to edit_task_path(@task) , notice: '登録に成功しました。' }
       else
-        format.html{redirect_to new_task_path , notice: '登録に失敗しました。' }
+        format.html{render "new"}
       end
     end
   end
@@ -57,8 +57,7 @@ class TasksController < ApplicationController
       if @task.update(task_params)==true
         format.html{redirect_to edit_task_path(@task) , notice: '更新に成功しました。' }
       else
-        format.html{redirect_to edit_task_path(@task) ,
-           notice: '更新に失敗しました。もう一度更新するか、はじめからやり直してください。' }
+        format.html{render "edit"}
       end
     end
   end

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -1,15 +1,11 @@
-<%= form_with(model: task, local: true) do |form| %>
-  <% if task.errors.any? %>
-    <div id="error_explanation">
-      <h2><%= pluralize(task.errors.count, "error") %> prohibited this task from being saved:</h2>
+<!--↑エラーメッセージ表示枠……バリデーションエラーを出す画面ではこれを追加しておくこと。-->
+<% content_for :show_msgerr do%>
+  <%= render 'layouts/form_msgerr', model_info: task %>
+<% end %>
+<!--↑エラーメッセージ表示枠-->
 
-      <ul>
-      <% task.errors.full_messages.each do |message| %>
-        <li><%= message %></li>
-      <% end %>
-      </ul>
-    </div>
-  <% end %>
+<%= form_with(model: task, local: true) do |form| %>
+
 
   <%= form.label "※メモ：担当者は後回し、暫定で「1」を登録" %>
   <div class="">

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -155,6 +155,7 @@ ja:
       header:
         one: "%{model}にエラーが発生しました"
         other: "%{model}に%{count}個のエラーが発生しました"
+        none: "エラーが発生しました"
   helpers:
     select:
       prompt: 選択してください

--- a/db/migrate/20190414134804_add_index_to_tasks.rb
+++ b/db/migrate/20190414134804_add_index_to_tasks.rb
@@ -1,0 +1,8 @@
+class AddIndexToTasks < ActiveRecord::Migration[5.2]
+
+  def change
+    add_index :tasks , :name , unique: true
+    change_column :tasks , :name , :string , limit: 20
+    change_column :tasks , :content , :text , limit: 120
+  end
+end

--- a/db/migrate/20190414141923_add_index_to_tasks2.rb
+++ b/db/migrate/20190414141923_add_index_to_tasks2.rb
@@ -1,0 +1,5 @@
+class AddIndexToTasks2 < ActiveRecord::Migration[5.2]
+  def change
+    change_column :tasks , :content , :text , limit: 400
+  end
+end

--- a/db/migrate/20190414143302_add_index_content_to_tasks3.rb
+++ b/db/migrate/20190414143302_add_index_content_to_tasks3.rb
@@ -1,0 +1,5 @@
+class AddIndexContentToTasks3 < ActiveRecord::Migration[5.2]
+  def change
+    change_column :tasks , :content , :text , limit: 120
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,20 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_09_021004) do
+ActiveRecord::Schema.define(version: 2019_04_14_143302) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "tasks", force: :cascade do |t|
     t.bigint "user_id", null: false
-    t.string "name", null: false
+    t.string "name", limit: 20, null: false
     t.text "content", null: false
     t.datetime "limit"
     t.integer "priority", default: 2, null: false
     t.integer "status", default: 0, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_tasks_on_name", unique: true
   end
 
 end

--- a/spec/features/projects_spec.rb
+++ b/spec/features/projects_spec.rb
@@ -103,7 +103,7 @@ RSpec.feature "Projects", type: :feature do
     click_button I18n.t('helpers.submit.create')
 
     expect(page).to have_content I18n.t('screen.new',name: I18n.t('activerecord.models.task'))
-    expect(page).to have_content I18n.t('activerecord.errors.messages.failed_save')
+    expect(page).to have_content I18n.t('errors.template.header.none')
   end
 
   scenario "タスク名だけ入力して登録すると登録成功" do


### PR DESCRIPTION
「dbへのバリデーション制限」「モデルへのバリデーション制限」「バリデーションについてのテスト」はすでに作成済み（「ステップ8、テスト」への対応時などに、すでに記述していた）ため、今回変更は「ビュー」「コントローラー」「featureテスト（テスト時に発生するエラー文言変更）」のみになります。→確認し直したところ、「dbへのバリデーション制限」が抜けていたため追加修正しました。